### PR TITLE
Added feature enableLimits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This component accepts following props:
 * `enableScale` : false to disable scale. Default is true.
 * `enableTranslate` : false to disable translateX/Y. Default is true.
 * `maxScale` : a number. Default is 1.
-* `enableResistance`  : true to resist over pan. Defaul is false.
+* `enableResistance` : true to resist over pan. Default is false.
+* `enableLimits` : true so that the view cannot be moved out of its viewport. Default is false.
 * `maxOverScrollDistance` : a number used to determine final scroll position triggered by fling. Default is 20.
 * `onViewTransformed` : a callback called when transform changed, receiving current transform object, {scale: xxx, translateX: xxx, translateY: xxx}.
 * `onTransformGestureReleased` : a callback called when the transform gesture is released,  receiving current transform object, {scale: xxx, translateX: xxx, translateY: xxx}. Return true to abort further animations like bounce back.

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
   View,
   Animated,
@@ -55,12 +56,6 @@ export default class ViewTransformer extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.initialScale != nextProps.initialScale) {
-      this.updateTransform({ scale: nextProps.initialScale })
-    }
-  }
-
   viewPortRect() {
     this._viewPortRect.set(0, 0, this.state.width, this.state.height);
     return this._viewPortRect;
@@ -95,7 +90,10 @@ export default class ViewTransformer extends React.Component {
       onResponderGrant: this.onResponderGrant.bind(this),
       onResponderRelease: this.onResponderRelease.bind(this),
       onResponderTerminate: this.onResponderRelease.bind(this),
-      onResponderTerminationRequest: (evt, gestureState) => false //Do not allow parent view to intercept gesture
+      onResponderTerminationRequest: (evt, gestureState) => false, //Do not allow parent view to intercept gesture
+      onResponderSingleTapConfirmed: (evt, gestureState) => {
+        this.props.onSingleTapConfirmed && this.props.onSingleTapConfirmed();
+      }
     });
   }
 
@@ -122,18 +120,16 @@ export default class ViewTransformer extends React.Component {
         {...this.props}
         {...gestureResponder}
         ref={'innerViewRef'}
-        onLayout={this.onLayout.bind(this)}
-      >
+        onLayout={this.onLayout.bind(this)}>
         <View
           style={{
             flex: 1,
             transform: [
-              {scale: this.state.scale},
-              {translateX: this.state.translateX},
-              {translateY: this.state.translateY},
-            ]
-          }}
-        >
+                  {scale: this.state.scale},
+                  {translateX: this.state.translateX},
+                  {translateY: this.state.translateY}
+                ]
+          }}>
           {this.props.children}
         </View>
       </View>
@@ -489,36 +485,36 @@ ViewTransformer.propTypes = {
   /**
    * Use false to disable transform. Default is true.
    */
-  enableTransform: React.PropTypes.bool,
+  enableTransform: PropTypes.bool,
 
   /**
    * Use false to disable scaling. Default is true.
    */
-  enableScale: React.PropTypes.bool,
+  enableScale: PropTypes.bool,
 
   /**
    * Use false to disable translateX/translateY. Default is true.
    */
-  enableTranslate: React.PropTypes.bool,
+  enableTranslate: PropTypes.bool,
 
   /**
    * Default is 20
    */
-  maxOverScrollDistance: React.PropTypes.number,
+  maxOverScrollDistance: PropTypes.number,
 
-  initialScale: React.PropTypes.number,
-  maxScale: React.PropTypes.number,
-  contentAspectRatio: React.PropTypes.number,
+  initialScale: PropTypes.number,
+  maxScale: PropTypes.number,
+  contentAspectRatio: PropTypes.number,
 
   /**
    * Use true to enable resistance effect on over pulling. Default is false.
    */
-  enableResistance: React.PropTypes.bool,
-  enableLimits: React.PropTypes.bool,
+  enableResistance: PropTypes.bool,
+  enableLimits: PropTypes.bool,
 
-  onViewTransformed: React.PropTypes.func,
+  onViewTransformed: PropTypes.func,
 
-  onTransformGestureReleased: React.PropTypes.func
+  onTransformGestureReleased: PropTypes.func
 };
 ViewTransformer.defaultProps = {
   maxOverScrollDistance: 20,

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -55,6 +55,12 @@ export default class ViewTransformer extends React.Component {
     });
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.initialScale != nextProps.initialScale) {
+      this.updateTransform({ scale: nextProps.initialScale })
+    }
+  }
+
   viewPortRect() {
     this._viewPortRect.set(0, 0, this.state.width, this.state.height);
     return this._viewPortRect;
@@ -116,16 +122,18 @@ export default class ViewTransformer extends React.Component {
         {...this.props}
         {...gestureResponder}
         ref={'innerViewRef'}
-        onLayout={this.onLayout.bind(this)}>
+        onLayout={this.onLayout.bind(this)}
+      >
         <View
           style={{
             flex: 1,
             transform: [
-                  {scale: this.state.scale},
-                  {translateX: this.state.translateX},
-                  {translateY: this.state.translateY}
-                ]
-          }}>
+              {scale: this.state.scale},
+              {translateX: this.state.translateX},
+              {translateY: this.state.translateY},
+            ]
+          }}
+        >
           {this.props.children}
         </View>
       </View>

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -134,14 +134,10 @@ export default class ViewTransformer extends React.Component {
 
   onLayout(e) {
     const {width, height} = e.nativeEvent.layout;
-    if(width !== this.state.width || height !== this.state.height) {
+    if (width !== this.state.width || height !== this.state.height) {
       this.setState({width, height});
     }
     this.measureLayout();
-
-    if (this.props.enableLimits) {
-      setTimeout(() => this.animateBounce(), 1);
-    }
 
     this.props.onLayout && this.props.onLayout(e);
   }
@@ -194,13 +190,12 @@ export default class ViewTransformer extends React.Component {
       let pivotY = gestureState.moveY - this.state.pageY;
 
 
-      let rect = transformedRect(transformedRect(this.contentRect(), this.currentTransform()), new Transform(
-        scaleBy, dx, dy,
-        {
-          x: pivotX,
-          y: pivotY
-        }
-      ));
+      let rect = transformedRect(
+        transformedRect(this.contentRect(), this.currentTransform()),
+        new Transform(
+          scaleBy, dx, dy, { x: pivotX, y: pivotY }
+        )
+      );
       transform = getTransform(this.contentRect(), rect);
     } else {
       if (Math.abs(dx) > 2 * Math.abs(dy)) {
@@ -250,11 +245,6 @@ export default class ViewTransformer extends React.Component {
       }
     }
   }
-
-
-
-
-
 
   performFling(vx, vy) {
     let startX = 0;

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -19,9 +19,10 @@ export default class ViewTransformer extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.state = {
       //transform state
-      scale: 1,
+      scale: props.initialScale,
       translateX: 0,
       translateY: 0,
 
@@ -507,6 +508,7 @@ ViewTransformer.propTypes = {
    */
   maxOverScrollDistance: React.PropTypes.number,
 
+  initialScale: React.PropTypes.number,
   maxScale: React.PropTypes.number,
   contentAspectRatio: React.PropTypes.number,
 
@@ -525,6 +527,7 @@ ViewTransformer.defaultProps = {
   enableScale: true,
   enableTranslate: true,
   enableTransform: true,
+  initialScale: 1,
   maxScale: 1,
   enableResistance: false,
   enableLimits: false,


### PR DESCRIPTION
Hi @ldn0x7dc 

First thanks for this project and also `react-native-transformable-image`, they are both incredible. I've been modifying some parts of both libraries and I'm going to submit some PRs with what I think could be useful to everyone out there. I want to first say that the code of both libraries is super clean and easy to follow, you've done an amazing work.

This PR adds a prop called `enableLimits` Activating this prop, the view cannot be moved out of its viewport. This is the typical default behavior in any Android native photoview library. 

I'm using this in my personal project, because I wanted transformable-image to behave the closest possible to other native libraries.

Thanks, cheers
Miguel
