### PR TITLE
Add new onResponder release callbacks as props

### DIFF
--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -244,7 +244,7 @@ export default class ViewTransformer extends React.Component {
       }
     } else {
       if(this.props.enableTranslate) {
-        this.performFling(gestureState.vx, gestureState.vy);
+        this.props.enableFling && this.performFling(gestureState.vx, gestureState.vy);
       } else {
         this.animateBounce();
       }
@@ -452,6 +452,11 @@ ViewTransformer.propTypes = {
    * Use true to enable resistance effect on over pulling. Default is false.
    */
   enableResistance: React.PropTypes.bool,
+  /**
+   * Use false to disable flinging back after moving the image away from the center.
+   * Default is true.
+   */
+  enableFling: React.PropTypes.bool,
 
   onViewTransformed: React.PropTypes.func,
 
@@ -480,6 +485,7 @@ ViewTransformer.defaultProps = {
   enableTransform: true,
   maxScale: 1,
   enableResistance: false,
+  enableFling: true,
   onSingleTap: undefined,
   onSingleTapConfirmed: undefined,
   onDoubleTap: undefined,

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -219,6 +219,9 @@ export default class ViewTransformer extends React.Component {
       return;
     }
 
+    if (gestureState.singleTapUp) {
+      this.props.onSingleTap && this.props.onSingleTap();
+    }
 
     if (gestureState.doubleTapUp) {
       if (!this.props.enableScale) {
@@ -450,7 +453,8 @@ ViewTransformer.propTypes = {
 
   onTransformGestureReleased: React.PropTypes.func,
 
-  onSingleTapConfirmed: React.PropTypes.func
+  onSingleTap: React.PropTypes.func,
+  onSingleTapConfirmed: React.PropTypes.func,
 };
 ViewTransformer.defaultProps = {
   maxOverScrollDistance: 20,
@@ -458,5 +462,7 @@ ViewTransformer.defaultProps = {
   enableTranslate: true,
   enableTransform: true,
   maxScale: 1,
-  enableResistance: false
+  enableResistance: false,
+  onSingleTap: undefined,
+  onSingleTapConfirmed: undefined,
 };

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -237,7 +237,11 @@ export default class ViewTransformer extends React.Component {
         pivotY = gestureState.y0 - this.state.pageY;
       }
 
-      this.performDoubleTapUp(pivotX, pivotY);
+      if (this.props.onDoubleTap) {
+        this.props.onDoubleTap(pivotX, pivotY);
+      } else {
+        this.performDoubleTapUp(pivotX, pivotY);
+      }
     } else {
       if(this.props.enableTranslate) {
         this.performFling(gestureState.vx, gestureState.vy);
@@ -453,8 +457,21 @@ ViewTransformer.propTypes = {
 
   onTransformGestureReleased: React.PropTypes.func,
 
+  /**
+   * Callback on a single tap (includes first and second tap of double-tap)
+   */
   onSingleTap: React.PropTypes.func,
+  /**
+   * Callback on a single tap which is not part of a double-tap
+   */
   onSingleTapConfirmed: React.PropTypes.func,
+  /**
+   * Callback on a double tap (if supplied, it overwrites default scaling behavior)
+   *
+   * The first two arguments of the callback are the x- and y-coordinates of the
+   * finger while tapping, respectively.
+   */
+  onDoubleTap: React.PropTypes.func,
 };
 ViewTransformer.defaultProps = {
   maxOverScrollDistance: 20,
@@ -465,4 +482,5 @@ ViewTransformer.defaultProps = {
   enableResistance: false,
   onSingleTap: undefined,
   onSingleTapConfirmed: undefined,
+  onDoubleTap: undefined,
 };


### PR DESCRIPTION
Adds new props `onSingleTap`, `onDoubleTap` and `enableFling` to give the user of the package more options. 

`onSingleTapConfirmed` was a very good addition, but sometimes you may want to add custom behavior on single or double taps. That's what this pull-requests added.

This does does not break any current usages. All new props are optional and the default of `enableFling` is set to true which reflects the current behavior.

This pull-request is complemented by https://github.com/ldn0x7dc/react-native-transformable-image/pull/20 for users of `react-native-transformable-image`.