### PR TITLE
Converting React.proptypes into Proptypes

### DIFF
--- a/Demo/package.json
+++ b/Demo/package.json
@@ -6,8 +6,8 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react": "15.2.1",
-    "react-native": "^0.29.2",
+    "react": "16.2.0",
+    "react-native": "^0.50.4",
     "react-native-view-transformer": "0.0.28"
   }
 }

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -12,7 +12,7 @@ import {createResponder} from 'react-native-gesture-responder';
 import Scroller from 'react-native-scroller';
 import {Rect, Transform, transformedRect, availableTranslateSpace, fitCenterRect, alignedRect, getTransform} from './TransformUtils';
 
-export default class ViewTransformer extends React.Component {
+export default class ViewTransformer extends Component {
 
   static Rect = Rect;
   static getTransform = getTransform;

--- a/library/transform/ViewTransformer.js
+++ b/library/transform/ViewTransformer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React from 'react';
+import React, { PropTypes, Component } from 'react';
 import ReactNative, {
   View,
   Animated,
@@ -421,36 +421,36 @@ ViewTransformer.propTypes = {
   /**
    * Use false to disable transform. Default is true.
    */
-  enableTransform: React.PropTypes.bool,
+  enableTransform: PropTypes.bool,
 
   /**
    * Use false to disable scaling. Default is true.
    */
-  enableScale: React.PropTypes.bool,
+  enableScale: PropTypes.bool,
 
   /**
    * Use false to disable translateX/translateY. Default is true.
    */
-  enableTranslate: React.PropTypes.bool,
+  enableTranslate: PropTypes.bool,
 
   /**
    * Default is 20
    */
-  maxOverScrollDistance: React.PropTypes.number,
+  maxOverScrollDistance: PropTypes.number,
 
-  maxScale: React.PropTypes.number,
-  contentAspectRatio: React.PropTypes.number,
+  maxScale: PropTypes.number,
+  contentAspectRatio: PropTypes.number,
 
   /**
    * Use true to enable resistance effect on over pulling. Default is false.
    */
-  enableResistance: React.PropTypes.bool,
+  enableResistance: PropTypes.bool,
 
-  onViewTransformed: React.PropTypes.func,
+  onViewTransformed: PropTypes.func,
 
-  onTransformGestureReleased: React.PropTypes.func,
+  onTransformGestureReleased: PropTypes.func,
 
-  onSingleTapConfirmed: React.PropTypes.func
+  onSingleTapConfirmed: PropTypes.func
 };
 ViewTransformer.defaultProps = {
   maxOverScrollDistance: 20,

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-view-transformer",
   "version": "0.0.28",
-  "description": "A pure JavaScript RN component that makes ANY views transformable using gestures like pinch, double tap or pull.",
+  "description": "Updating PropTypes to latest React Version",
   "main": "library/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "author": "Mahesh Nandam",
   "license": "ISC",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Indeed, 

Latest React has prop-types though no need to import separately.